### PR TITLE
Update help command to use html formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,14 +34,14 @@ class RenderMonitorBot:
     
     async def help_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """רשימת פקודות"""
-        message = "📋 *רשימת פקודות:*\n\n"
+        message = "📋 <b>רשימת פקודות:</b>\n\n"
         message += "/start - התחלה\n"
-        message += "/status - מצב כל השירותים\n"  
+        message += "/status - מצב כל השירותים\n"
         message += "/suspend - השעיית כל השירותים\n"
         message += "/resume - החזרת כל השירותים המושעים\n"
         message += "/list_suspended - רשימת שירותים מושעים\n"
         message += "/help - עזרה\n"
-        await update.message.reply_text(message, parse_mode="Markdown")
+        await update.message.reply_text(message, parse_mode="HTML")
     
     async def status_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """הצגת מצב כל השירותים"""


### PR DESCRIPTION
Switch `help_command` message parsing from Markdown to HTML.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c6685f8-0aab-4a20-b94e-2d6357028cab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c6685f8-0aab-4a20-b94e-2d6357028cab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>