### PR TITLE
Update to mongodb lock mechanism

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def cleanup_mongo_lock():
         print(f"ERROR: Could not release MongoDB lock on exit: {e}")
 
 def manage_mongo_lock():
-    """מנהל נעילה ב-MongoDB כדי למנוע ריצה כפולה"""
+    """מנהל נעילה ב-MongoDB כדי למנוע ריצה כפולה עם יציאה נקייה."""
     pid = os.getpid()
     now = datetime.now(timezone.utc)
     
@@ -54,8 +54,8 @@ def manage_mongo_lock():
             db.db.locks.delete_one({"_id": LOCK_ID})
         else:
             # אם המנעול לא ישן, זה אומר שתהליך אחר רץ
-            print(f"ERROR: Lock document in MongoDB exists. Another instance (PID {lock.get('pid')}) is likely running. Exiting.")
-            sys.exit(1)
+            print(f"INFO: Lock document in MongoDB exists. Another instance is running. Exiting gracefully.")
+            sys.exit(0)
 
     # מנסים ליצור נעילה חדשה. פעולה זו תצליח רק אם אין מסמך עם אותו _id
     try:
@@ -69,8 +69,8 @@ def manage_mongo_lock():
         print(f"INFO: MongoDB lock acquired by process {pid}.")
     except DuplicateKeyError:
         # אם מישהו אחר יצר את הנעילה בדיוק באותו רגע
-        print(f"ERROR: Lock was acquired by another process just now. Exiting.")
-        sys.exit(1)
+        print(f"INFO: Lock was acquired by another process just now. Exiting gracefully.")
+        sys.exit(0)
     except Exception as e:
         print(f"ERROR: Failed to acquire MongoDB lock: {e}")
         sys.exit(1)


### PR DESCRIPTION
Update MongoDB lock management to allow graceful exit on existing or concurrent lock acquisition.

This changes the bot's behavior from exiting with an error code to exiting gracefully when another instance is detected, treating it as a normal operational state.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbe4aaec-a0db-49af-85bf-1ed66a228fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbe4aaec-a0db-49af-85bf-1ed66a228fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>