### PR TITLE
Add confirmation button for bot availability notifications

### DIFF
--- a/activity_tracker.py
+++ b/activity_tracker.py
@@ -110,6 +110,7 @@ class ActivityTracker:
         if result["success"]:
             # עדכון במסד הנתונים
             db.update_service_activity(service_id, status="suspended")
+            db.update_last_known_status(service_id, "suspended")
             db.increment_suspend_count(service_id)
             print(f"שירות {service_name} הושעה ידנית בהצלחה")
         else:
@@ -131,6 +132,7 @@ class ActivityTracker:
         if result["success"]:
             # עדכון במסד הנתונים
             db.update_service_activity(service_id, status="active")
+            db.update_last_known_status(service_id, "active")
             
             # שליחת התראה על החזרה מוצלחת
             message = f"✅ החזרה לפעילות מוצלחת\n"

--- a/main.py
+++ b/main.py
@@ -209,6 +209,7 @@ class RenderMonitorBot:
             print(f"Attempting to suspend service with ID: {service_id}")
             self.render_api.suspend_service(service_id)
             self.db.update_service_activity(service_id, status="suspended")
+            self.db.update_last_known_status(service_id, "suspended")
             self.db.increment_suspend_count(service_id)
             await update.message.reply_text(f"✅ השירות {service_id} הושהה בהצלחה.")
             print(f"Successfully suspended service {service_id}.")
@@ -320,6 +321,7 @@ class RenderMonitorBot:
             try:
                 self.render_api.suspend_service(service_id)
                 self.db.update_service_activity(service_id, status="suspended")
+                self.db.update_last_known_status(service_id, "suspended")
                 await query.edit_message_text(text=f"✅ השירות {service_id} הושהה בהצלחה.")
             except Exception as e:
                 await query.edit_message_text(text=f"❌ כישלון בהשעיית {service_id}: {e}")
@@ -327,6 +329,7 @@ class RenderMonitorBot:
             try:
                 self.render_api.resume_service(service_id)
                 self.db.update_service_activity(service_id, status="active")
+                self.db.update_last_known_status(service_id, "active")
                 await query.edit_message_text(text=f"✅ השירות {service_id} הופעל מחדש.")
             except Exception as e:
                 await query.edit_message_text(text=f"❌ כישלון בהפעלת {service_id}: {e}")
@@ -348,6 +351,7 @@ class RenderMonitorBot:
                     try:
                         self.render_api.suspend_service(service['_id'])
                         self.db.update_service_activity(service['_id'], status="suspended")
+                        self.db.update_last_known_status(service['_id'], "suspended")
                         self.db.increment_suspend_count(service['_id'])
                         suspended_count += 1
                     except Exception as e:


### PR DESCRIPTION
Prevent availability alerts for manually changed service statuses.

Updates `last_known_status` in the database immediately when a service is manually suspended or resumed via the bot, ensuring alerts are only sent for external status changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ebb7044-3e7d-4d1d-89a8-945a53f3c950">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ebb7044-3e7d-4d1d-89a8-945a53f3c950">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

