### PR TITLE
Fix datetime timezone error in alerts

### DIFF
--- a/activity_tracker.py
+++ b/activity_tracker.py
@@ -38,7 +38,10 @@ class ActivityTracker:
         # בדיקה אם כבר נשלחה התראה היום
         last_alert = service.get("notification_settings", {}).get("last_alert_sent")
         if last_alert:
-            time_since_alert = datetime.now(timezone.utc) - last_alert
+            now_utc = datetime.now(timezone.utc)
+            if last_alert.tzinfo is None:
+                last_alert = last_alert.replace(tzinfo=timezone.utc)
+            time_since_alert = now_utc - last_alert
             if time_since_alert.days < 1:
                 return  # כבר נשלחה התראה היום
         


### PR DESCRIPTION
Normalize `last_alert` to UTC-aware datetime to fix `TypeError: can't subtract offset-naive and offset-aware datetimes`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3aa8eb0e-de54-456d-b3e9-e21cd29b6f4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3aa8eb0e-de54-456d-b3e9-e21cd29b6f4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

