### PR TITLE
Fix missing monitor_manage command handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -241,7 +241,59 @@ class RenderMonitorBot:
         
         await update.message.reply_text(message, parse_mode='Markdown')
     
-
+    async def monitor_manage_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """ניהול ניטור סטטוס דרך פקודה"""
+        services = self.db.get_all_services()
+        
+        if not services:
+            await update.message.reply_text("📭 אין שירותים במערכת")
+            return
+        
+        keyboard = []
+        
+        for service in services:
+            service_id = service["_id"]
+            service_name = service.get("service_name", service_id)
+            
+            # סטטוס נוכחי
+            current_status = service.get("last_known_status", "unknown")
+            status_emoji = "🟢" if current_status == "online" else "🔴" if current_status == "offline" else "🟡"
+            
+            # אימוג'י ניטור
+            monitoring_status = status_monitor.get_monitoring_status(service_id)
+            is_monitored = monitoring_status.get("enabled", False)
+            monitor_emoji = "👁️" if is_monitored else "👁️‍🗨️"
+            
+            button_text = f"{status_emoji} {monitor_emoji} {service_name[:20]}"
+            keyboard.append([
+                InlineKeyboardButton(
+                    button_text,
+                    callback_data=f"monitor_detail_{service_id}"
+                )
+            ])
+        
+        # כפתורים נוספים
+        keyboard.append([
+            InlineKeyboardButton("📊 הצג רק מנוטרים", callback_data="show_monitored_only")
+        ])
+        keyboard.append([
+            InlineKeyboardButton("🔄 רענן", callback_data="refresh_monitor_manage")
+        ])
+        
+        reply_markup = InlineKeyboardMarkup(keyboard)
+        
+        message = "🎛️ *ניהול ניטור סטטוס*\n\n"
+        message += "👁️ = בניטור | 👁️‍🗨️ = לא בניטור\n"
+        message += "🟢 = פעיל | 🔴 = כבוי | 🟡 = לא ידוע\n\n"
+        message += "בחר שירות לניהול:"
+        
+        await update.message.reply_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode='Markdown'
+        )
+        
+    
     async def clear_test_data_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """מחיקת נתוני בדיקות דמה"""
         # בדיקת הרשאות (רק אדמין)
@@ -251,9 +303,9 @@ class RenderMonitorBot:
         
         count = db.clear_test_data()
         await update.message.reply_text(f"✅ נמחקו {count} פעולות בדיקה\n✅ אופסו סטטוסים ונתוני פעילות של שירותים בבדיקה")
+        
     
-
-
+    
     async def status_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """הצגת מצב כל השירותים"""
         services = db.get_all_services()
@@ -292,6 +344,7 @@ class RenderMonitorBot:
             message += "\n"
         
         await update.message.reply_text(message, parse_mode="Markdown")
+        
     
     async def suspend_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """שולח בקשת אישור להשעיית כל השירותים"""
@@ -307,6 +360,7 @@ class RenderMonitorBot:
             reply_markup=reply_markup,
             parse_mode="HTML"
         )
+        
     
     async def suspend_one_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """השעיית שירות ספציפי"""


### PR DESCRIPTION
Adds `monitor_manage_command` to resolve `AttributeError` and enable the `/monitor_manage` Telegram command.

The bot was crashing on startup because a `CommandHandler` was registered for `/monitor_manage` but the `monitor_manage_command` method was missing in `RenderMonitorBot`. This PR implements the missing method, reusing existing UI logic, to resolve the `AttributeError` and make the command functional.

---
<a href="https://cursor.com/background-agent?bcId=bc-768e0f1c-76de-4948-8960-881c94c4d331">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-768e0f1c-76de-4948-8960-881c94c4d331">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

