### PR TITLE
Check deployment notification setup

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,8 @@ CHECK_INTERVAL_HOURS = 24  # בדיקה כל כמה שעות
 # הגדרות ניטור סטטוס
 STATUS_CHECK_INTERVAL_SECONDS = int(os.getenv("STATUS_CHECK_INTERVAL_SECONDS", "300"))  # 5 minutes default
 STATUS_MONITORING_ENABLED = os.getenv("STATUS_MONITORING_ENABLED", "true").lower() == "true"
+# New: while any service is deploying, poll faster to catch transitions
+DEPLOY_CHECK_INTERVAL_SECONDS = int(os.getenv("DEPLOY_CHECK_INTERVAL_SECONDS", "30"))
 
 # הגדרות כלליות
 TIMEZONE = "Asia/Jerusalem"

--- a/notifications.py
+++ b/notifications.py
@@ -41,7 +41,9 @@ def send_status_change_notification(service_id: str, service_name: str,
     """שליחת התראה על שינוי סטטוס של שירות"""
     message = f"{emoji} *התראת שינוי סטטוס*\n\n"
     message += f"🤖 השירות: *{service_name}*\n"
-    message += f"🆔 ID: `{service_id}`\n"
+    # בטלגרם backticks יכולים לשבור Markdown אם יש תווים מיוחדים ב-ID, נחליף backtick חזרה
+    safe_service_id = str(service_id).replace('`', '\\`')
+    message += f"🆔 ID: `{safe_service_id}`\n"
     message += f"📊 הפעולה: {action}\n"
     message += f"⬅️ סטטוס קודם: {old_status}\n"
     message += f"➡️ סטטוס חדש: {new_status}\n\n"


### PR DESCRIPTION
Improve deploy notification reliability by expanding status detection, accelerating polling during deployments, and refining notification messages.

The previous setup often missed deploy completion notifications because it only triggered on a direct "deploying" to "online" transition, which could be missed with a 5-minute polling interval. This PR addresses this by introducing faster polling during active deployments and broadening the range of statuses recognized as "deploying" to ensure transitions are caught and appropriate notifications are sent. A new test command is also added for easier verification.

---
<a href="https://cursor.com/background-agent?bcId=bc-0472f590-6619-4811-b2b3-d991a61efc48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0472f590-6619-4811-b2b3-d991a61efc48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

