### PR TITLE
Show service pricing and disk add-ons

### DIFF
--- a/main.py
+++ b/main.py
@@ -143,6 +143,7 @@ class RenderMonitorBot:
         commands = [
             BotCommand("start", "🚀 הפעלת הבוט"),
             BotCommand("status", "📊 סטטוס כל השירותים"),
+            BotCommand("plans", "💳 מידע על תוכנית ודיסק לכל שירות"),
             BotCommand("manage", "🎛️ ניהול שירותים"),
             BotCommand("monitor_manage", "👁️ ניהול ניטור סטטוס"),
             BotCommand("suspend", "⏸️ השעיית כל השירותים"),
@@ -277,7 +278,10 @@ class RenderMonitorBot:
                 disk_emoji = "💽" if has_disk else "—"
 
                 plan_display = plan_str or "לא ידוע"
-                lines.append(f"{status_emoji} *{name}*\n   ID: `{sid}`\n   תוכנית: {plan_display}\n   דיסק: {disk_emoji}\n")
+                kind_text = "חינמי" if is_free is True else ("בתשלום" if is_free is False else "לא ידוע")
+                lines.append(
+                    f"{status_emoji} *{name}*\n   ID: `{sid}`\n   תוכנית: {plan_display} ({kind_text})\n   דיסק: {disk_emoji}\n"
+                )
 
             await msg.reply_text("\n".join(lines), parse_mode="Markdown")
         except Exception as e:


### PR DESCRIPTION
Add a new `/plans` Telegram command to list each Render service's plan (free/paid) and persistent disk status.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ab5fdb3-e8ee-4499-a2ea-82a84120a01f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ab5fdb3-e8ee-4499-a2ea-82a84120a01f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

