### PR TITLE
Disable daily report scheduler task

### DIFF
--- a/main.py
+++ b/main.py
@@ -2931,8 +2931,8 @@ def run_scheduler():
     # בדיקה יומית בשעה 09:00
     schedule.every().day.at("09:00").do(activity_tracker.check_inactive_services)
 
-    # דוח יומי בשעה 20:00
-    schedule.every().day.at("20:00").do(send_daily_report)
+    # דוח יומי בשעה 20:00 - מבוטל
+    # schedule.every().day.at("20:00").do(send_daily_report)
 
     # בדיקת תזכורות כל דקה
     schedule.every(1).minutes.do(check_and_send_reminders)


### PR DESCRIPTION
## Summary
Disabled the daily report scheduling task that was previously running at 20:00.

## Changes
- Commented out the `send_daily_report()` scheduled task that executed daily at 20:00
- Added a note indicating the task has been disabled ("מבוטל" - disabled in Hebrew)

## Details
The daily report generation scheduled job has been disabled while keeping the code in place for potential future re-enablement. Other scheduler tasks remain active, including the inactive services check at 09:00 and the reminder check running every minute.

https://claude.ai/code/session_01NJs6QhcyLmnfMGmFBoPHub